### PR TITLE
GPT-51 Change the “date” search currently in AuScope Portal to a “yea…

### DIFF
--- a/src/main/java/org/auscope/portal/gsml/BoreholeFilter.java
+++ b/src/main/java/org/auscope/portal/gsml/BoreholeFilter.java
@@ -72,7 +72,7 @@ public class BoreholeFilter extends AbstractFilter {
         if (dateOfDrilling != null && !dateOfDrilling.isEmpty()) {
             parameterFragments.add(this.generatePropertyIsLikeFragment(
                     "gsml:indexData/gsml:BoreholeDetails/gsml:dateOfDrilling",
-                    this.dateOfDrilling));
+                    "*" +  this.dateOfDrilling + "*"));
         }
 
         if (this.restrictToIDList != null && !this.restrictToIDList.isEmpty()) {

--- a/src/main/java/org/auscope/portal/gsml/SF0BoreholeFilter.java
+++ b/src/main/java/org/auscope/portal/gsml/SF0BoreholeFilter.java
@@ -62,7 +62,7 @@ public class SF0BoreholeFilter extends BoreholeFilter {
         if (dateOfDrilling != null && !dateOfDrilling.isEmpty()) {
             parameterFragments.add(this.generatePropertyIsLikeFragment(
                     "gsmlp:drillStartDate",
-                    this.dateOfDrilling));
+                    "*" +  this.dateOfDrilling + "*"));
         }
 
         if (this.restrictToIDList != null && !this.restrictToIDList.isEmpty()) {

--- a/src/main/webapp/js/auscope/layer/filterer/forms/BoreholeFilterForm.js
+++ b/src/main/webapp/js/auscope/layer/filterer/forms/BoreholeFilterForm.js
@@ -66,11 +66,10 @@ Ext.define('auscope.layer.filterer.forms.BoreholeFilterForm', {
                     fieldLabel: '<span data-qtip="Wildcards: \'!\' escape character; \'*\' zero or more, \'#\' just one character.">' + 'Name',
                     name: 'boreholeName'
                 },{                   	
-                    xtype: 'datefield',
+                    xtype: 'textfield',
                     anchor: '95%',
                     itemId: 'drillingdate-field',
-                    fieldLabel: 'Drill Date',
-                    format: "Y-m-d",
+                    fieldLabel: 'Drilling year',
                     value: '',
                     name: 'dateOfDrilling'
                 },{

--- a/src/main/webapp/js/auscope/layer/filterer/forms/SF0BoreholeFilterForm.js
+++ b/src/main/webapp/js/auscope/layer/filterer/forms/SF0BoreholeFilterForm.js
@@ -68,11 +68,10 @@ Ext.define('auscope.layer.filterer.forms.SF0BoreholeFilterForm', {
                     fieldLabel: '<span data-qtip="Wildcards: \'!\' escape character; \'*\' zero or more, \'#\' just one character.">' + 'Name',
                     name: 'boreholeName'
                 },{
-                    xtype: 'datefield',
+                    xtype: 'textfield',
                     anchor: '95%',
                     itemId: 'drillingdate-field',
-                    fieldLabel: 'Drill Date',
-                    format: "Y-m-d",
+                    fieldLabel: 'Drilling year',
                     value: '',
                     name: 'dateOfDrilling'
                 },{

--- a/src/test/java/org/auscope/portal/server/web/service/TestBoreholeService.java
+++ b/src/test/java/org/auscope/portal/server/web/service/TestBoreholeService.java
@@ -107,6 +107,48 @@ public class TestBoreholeService extends PortalTestClass {
     }
 
     /**
+     * Test get all boreholes no bbox and with year only in the dateOfDrilling field.
+     *
+     * @throws Exception
+     *             the exception
+     */
+    @Test
+    public void testGetAllBoreholesDrillYearOnly() throws Exception {
+        final FilterBoundingBox bbox = null;
+        final String serviceURL = "http://example.com";
+        final int maxFeatures = 45;
+        final String boreholeName = "borehole-name";
+        final String custodian = "custodian";
+        final String dateOfDrilling = "2011";
+        final String gmlString = "xmlString";
+        final String kmlString = "kmlString";
+        final List<String> restrictedIds = null;
+
+        context.checking(new Expectations() {
+            {
+
+                oneOf(mockMethodMaker).makePostMethod(with(equal(serviceURL)), with(equal("gsml:Borehole")),
+                        with(any(String.class)), with(equal(maxFeatures)), with(any(String.class)),
+                        with(equal(ResultType.Results)), with(equal((String) null)), with(equal((String) null)));
+                will(returnValue(mockMethod));
+
+                oneOf(mockHttpServiceCaller).getMethodResponseAsString(with(any(HttpRequestBase.class)));
+                will(returnValue(gmlString));
+
+                oneOf(mockGmlToKml).convert(gmlString, serviceURL);
+                will(returnValue(kmlString));
+            }
+        });
+
+        WFSTransformedResponse result = service.getAllBoreholes(serviceURL, boreholeName, custodian, dateOfDrilling,
+                maxFeatures, bbox, restrictedIds);
+        Assert.assertNotNull(result);
+        Assert.assertEquals(gmlString, result.getGml());
+        Assert.assertEquals(kmlString, result.getTransformed());
+        Assert.assertSame(mockMethod, result.getMethod());
+    }
+    
+    /**
      * Test get all boreholes bbox.
      *
      * @throws Exception

--- a/src/test/java/org/auscope/portal/server/web/service/TestSF0BoreholeService.java
+++ b/src/test/java/org/auscope/portal/server/web/service/TestSF0BoreholeService.java
@@ -106,6 +106,47 @@ public class TestSF0BoreholeService extends PortalTestClass {
     }
 
     /**
+     * Test get all boreholes no bbox and with year only in the date of drilling field.
+     *
+     * @throws Exception
+     *             the exception
+     */
+    @Test
+    public void testGetAllBoreholesNoBboxDrillYearOnly() throws Exception {
+        final FilterBoundingBox bbox = null;
+        final String serviceURL = "http://example.com";
+        final int maxFeatures = 45;
+        final String boreholeName = "borehole-name";
+        final String custodian = "custodian";
+        final String dateOfDrilling = "2011";
+        final String gmlString = "xmlString";
+        final String kmlString = "kmlString";
+
+        context.checking(new Expectations() {
+            {
+
+                oneOf(mockMethodMaker).makePostMethod(with(equal(serviceURL)), with(equal("gsmlp:BoreholeView")),
+                        with(any(String.class)), with(equal(maxFeatures)), with(any(String.class)),
+                        with(equal(ResultType.Results)), with(equal((String) null)), with(equal((String) null)));
+                will(returnValue(mockMethod));
+
+                oneOf(mockHttpServiceCaller).getMethodResponseAsString(with(any(HttpRequestBase.class)));
+                will(returnValue(gmlString));
+
+                oneOf(mockGmlToKml).convert(gmlString, serviceURL);
+                will(returnValue(kmlString));
+            }
+        });
+
+        WFSTransformedResponse result = service.getAllBoreholes(serviceURL, boreholeName, custodian, dateOfDrilling,
+                maxFeatures, bbox);
+        Assert.assertNotNull(result);
+        Assert.assertEquals(gmlString, result.getGml());
+        Assert.assertEquals(kmlString, result.getTransformed());
+        Assert.assertSame(mockMethod, result.getMethod());
+    }    
+    
+    /**
      * Test that SF0 filter style will return a style layer descriptor with correct feature type name
      */
     @Test


### PR DESCRIPTION
There are two different types of boreholes forms. For each, I've changed the date field to a text field, and added wildcards to the search parameter. Also added Junit test method. 
