### PR TITLE
Change header to cater for a specific resolution -

### DIFF
--- a/src/main/webapp/css/narrow-header.css
+++ b/src/main/webapp/css/narrow-header.css
@@ -1,0 +1,34 @@
+#header-container-innerCt {
+	height : 100px !important;
+}
+
+#panel-1091 {
+	height : 95px !important;
+	top : 5px !important;
+}
+
+#header-container-innerCt div#panel-1090 {
+	left: auto !important;
+	right : 10px !important;
+	top : 70px !important;
+	width : 225px !important;
+	z-index: 99;
+}
+
+#panel-1091-body {
+	height : 95px !important; 
+}
+
+#search-controls {
+	left : 37%;
+	left : 500px;
+	right : auto;
+	margin-right : 0 !important;
+	margin-top : 0 !important;
+	position : absolute;
+	top : 62px !important;
+}
+
+#gamenubar-1092 {
+	top : 75px !important;
+}

--- a/src/main/webapp/css/styles.css
+++ b/src/main/webapp/css/styles.css
@@ -111,6 +111,12 @@
 
     #search-controls a {
         color: white !important;
+        text-decoration : none;
+    }
+    
+    #search-controls a:hover,
+    #header-controls a:hover {
+    	text-decoration : underline;
     }
     
     #activeLayersPanel {

--- a/src/main/webapp/cssimports.htm
+++ b/src/main/webapp/cssimports.htm
@@ -2,3 +2,5 @@
 <link rel="stylesheet" type="text/css" href="css/menu.css">
 <link rel="stylesheet" type="text/css" href="css/auscope-graph.css">
 <link rel="stylesheet" type="text/css" href="css/styles.css">
+
+<link media="(min-width: 1059px) and (max-width: 1400px)" rel="stylesheet" href="css/narrow-header.css">


### PR DESCRIPTION
- '#search-controls' does not overlap the logo
- header links render alongside '#search-controls'

Current resolution set between 1059px and 1400px
Expected to be updated
