### PR TITLE
Portal header changes

### DIFF
--- a/src/main/webapp/css/styles.css
+++ b/src/main/webapp/css/styles.css
@@ -98,6 +98,15 @@
        width : 765px !important;
     }
     
+    div#wrapper-search-and-links a {
+        text-decoration : none !important;
+        font-size : 12px !important;
+    }
+    
+    div#wrapper-search-and-links a:hover {
+        text-decoration : underline !important;
+    }
+    
     #search-controls {
         clear: both;
         display: flex;      

--- a/src/main/webapp/css/styles.css
+++ b/src/main/webapp/css/styles.css
@@ -103,7 +103,8 @@
         font-size : 12px !important;
     }
     
-    div#wrapper-search-and-links a:hover {
+    div#wrapper-search-and-links a:hover,
+    div#wrapper-search-and-links a:focus {
         text-decoration : underline !important;
     }
     

--- a/src/main/webapp/css/styles.css
+++ b/src/main/webapp/css/styles.css
@@ -89,24 +89,24 @@
     
     /* wrapper for search controls and links */
     #header-container div#wrapper-search-and-links {
-       border-top : 1px solid #fff !important;
-       left : 0 !important;
-       padding : 1px 0;
-       position : relative !important;
-       top : 70px !important;
+       /* border-top : 1px solid #fff !important; */
+       left : auto !important;
+       padding : 0;
+       position : absolute !important;
+       right : 0 !important;
+       top : 68px !important;
+       width : 765px !important;
     }
     
     #search-controls {
-        float: right;
-        margin-top: 20px;
         clear: both;
         display: flex;      
         justify-content: space-between;
         color: white !important;
         line-height: 25px;
         height : 25px !important;
-        right : auto;
-        margin : 0 0 0 10px !important;
+        right : 255px;
+        left : auto !important;
         position : absolute;
         top : 0 !important;
     }
@@ -114,10 +114,8 @@
     #basic-search-input {
         height: 25px;
         border: 1px solid #ffffff;  
-        
-        margin-top : 2px;
         padding-left : 5px;
-        width : 330px;
+        width : 105px;
     }
 
     #search-controls label {
@@ -238,7 +236,6 @@
         width: 30px;
         background: #FBAD17 url( "../img/magglass.gif" ) no-repeat center center; 
         border: 1px solid #ffffff;    
-        margin-top : 2px;    
     }
     
     #clear-search-link {


### PR DESCRIPTION
- Search control and the links now render alongside - beneath the logo, right-aligned - irrespective of the screen resolution.
- The presentation for header links is now consistent (underlined on hover + focus).

![no-border-right-aligned-2](https://cloud.githubusercontent.com/assets/15813815/11857530/23f9f446-a4ad-11e5-8fd6-10517d1edaec.PNG)
![no-border-right-aligned-1](https://cloud.githubusercontent.com/assets/15813815/11857531/2434447a-a4ad-11e5-882f-bf4e4b978a54.PNG)
