### PR TITLE
GPT-131 default base map with session recovery

### DIFF
--- a/src/main/webapp/js/auscope/Main-UI.js
+++ b/src/main/webapp/js/auscope/Main-UI.js
@@ -435,7 +435,10 @@ Ext.application({
         } else {
             if(typeof(Storage) !== "undefined") {
                 decodedString = localStorage.getItem("geosciencePortalStoredApplicationState");
-                defaultBaseLayer = localStorage.getItem("geosciencePortalDefaultBaseLayer");
+                var serialisedBaseLayer = localStorage.getItem("geosciencePortalDefaultBaseLayer");
+                if (serialisedBaseLayer) {
+                    defaultBaseLayer = serialisedBaseLayer;
+                }
                 decodedVersion = null;
             }
         }

--- a/src/main/webapp/js/ga/widgets/GAMenuBar.js
+++ b/src/main/webapp/js/ga/widgets/GAMenuBar.js
@@ -66,6 +66,14 @@ Ext.define('ga.widgets.GAMenuBar', {
             me.map.map.zoomTo(4); 
             var center = new OpenLayers.LonLat(133.3, -26).transform('EPSG:4326', 'EPSG:3857');
             me.map.map.setCenter(center);
+
+            /* set the Base Layer for the map */ 
+            Ext.each(me.map.layerSwitcher.baseLayers, function(baseLayer) {
+                if (baseLayer.layer.name === "Google Satellite") {
+                    me.map.map.setBaseLayer(baseLayer.layer);
+                    return false;
+                }
+            });
             
             // remove all of the layers we have added
             var items = me.layerStore.data.items;    


### PR DESCRIPTION
reset map should reset the base map to the default
don't override default if local storage default map not present
