### PR TITLE
GPT-129 removed options from tenements filter

### DIFF
--- a/src/main/java/org/auscope/portal/mineraloccurrence/MineralTenementFilter.java
+++ b/src/main/java/org/auscope/portal/mineraloccurrence/MineralTenementFilter.java
@@ -25,7 +25,7 @@ public class MineralTenementFilter extends AbstractFilter {
 
         fragments = new ArrayList<String>();
         if (name != null && !name.isEmpty()) {
-            fragments.add(this.generatePropertyIsLikeFragment("mt:name", name));
+            fragments.add(this.generatePropertyIsLikeFragment("mt:name", "*" + name + "*"));
         }
         if (tenementType != null && !tenementType.isEmpty()) {
             fragments.add(this.generatePropertyIsLikeFragment("mt:tenementType", tenementType));

--- a/src/main/webapp/js/auscope/layer/filterer/forms/MineralTenementFilterForm.js
+++ b/src/main/webapp/js/auscope/layer/filterer/forms/MineralTenementFilterForm.js
@@ -91,42 +91,6 @@ Ext.define('auscope.layer.filterer.forms.MineralTenementFilterForm', {
                 },{
                     xtype: 'combo',
                     anchor: '100%',
-                    fieldLabel: 'Tenement Type',
-                    name: 'tenementType',
-                    typeAhead: true,
-                    triggerAction: 'all',
-                    lazyRender:true,
-                    mode: 'local',
-                    store: tenementTypeStore,
-                    valueField: 'valueText',
-                    displayField: 'displayText',
-                    hiddenName: 'valueText'
-                },{
-                    anchor: '100%',
-                    xtype: 'textfield',
-                    fieldLabel: '<span data-qtip="Wildcards: \'!\' escape character; \'*\' zero or more, \'#\' just one character.">' +
-                                    'owner' +
-                                '</span>',
-                    name: 'owner'
-                },{
-                    anchor: '100%',
-                    xtype: 'datefield',
-                    fieldLabel: '<span data-qtip="Tenement active till this date">' +
-                                'Tenement Expiry End Date' +
-                                '</span>',
-                    name: 'endDate',
-                    format: "Y-m-d",
-                    value: ''
-                },{
-                    anchor: '100%',
-                    xtype: 'textfield',
-                    fieldLabel: '<span data-qtip="Minimum size of the Tenement">' +
-                                'Min Size' +
-                                '</span>',
-                    name: 'size'
-                },{
-                    xtype: 'combo',
-                    anchor: '100%',
                     itemId: 'serviceFilter-field',
                     fieldLabel: 'Provider',
                     name: 'serviceFilter',


### PR DESCRIPTION
also added wildcards default on the name search

note the logic to handle the old search fields is still there, just not used as I figured it to be the quickest, easiest implementation of this requirement.
