### PR TITLE
GPT-156 modify drag drop listeners

### DIFF
--- a/src/main/webapp/js/auscope/widgets/panel/BaseActiveRecordPanel.js
+++ b/src/main/webapp/js/auscope/widgets/panel/BaseActiveRecordPanel.js
@@ -23,6 +23,19 @@ Ext.define('portal.widgets.panel.BaseActiveRecordPanel', {
     notVisibleIcon : 'img/eye_off.png',
     
     listenersHere : {
+        // when the component is ready, we can update its events
+        viewready: function(grid) {
+            var view = grid.getView(),
+                dd = view.findPlugin('gridviewdragdrop'),
+                pos;
+
+            // ignore drag events that didn't originate from the Name column
+            // this will allow default events like click inside the expanded panel to work
+            dd.dragZone.onBeforeDrag = function (data, e) {
+                pos = grid.getView().getPositionByEvent(e);
+                return pos.colIdx === 1;
+            }
+        }
     },
 
     constructor : function(cfg) {


### PR DESCRIPTION
Overridden onBeforeDrag method such that you can only drag on the Name column. Other drag gestures will be ignored, which means that click will work. It also means that you can only use the name column as a drag handle, which is not too bad actually
