### PR TITLE
GPT-223 Changed file name when .csv in the .zip file

### DIFF
--- a/src/main/java/org/auscope/portal/server/web/controllers/DownloadController.java
+++ b/src/main/java/org/auscope/portal/server/web/controllers/DownloadController.java
@@ -10,6 +10,8 @@ import java.util.zip.ZipOutputStream;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+import java.util.zip.ZipFile;
+import java.util.Enumeration;
 
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.logging.Log;
@@ -57,8 +59,25 @@ public class DownloadController extends BasePortalController {
         Progression progress = downloadTracker.getProgress();
         if (progress == Progression.COMPLETED) {
             response.setContentType("application/zip");
-            response.setHeader("Content-Disposition",
+
+            boolean csvSign = false;
+            ZipFile downloadZip = new ZipFile(downloadTracker.getFileHandle().getAbsolutePath());
+            Enumeration zipEntries = downloadZip.entries();
+            while (zipEntries.hasMoreElements()) {
+                String fileName = ((ZipEntry) zipEntries.nextElement()).getName();
+                if (fileName.contains("csv"))
+                {
+                    csvSign = true;
+                    break;
+                }
+            }
+
+            if (csvSign == false)
+                response.setHeader("Content-Disposition",
                     "inline; filename=GMLDownload.zip;");
+            else
+                response.setHeader("Content-Disposition",
+                    "inline; filename=CSVDownload.zip;");
             FileIOUtil.writeInputToOutputStream(downloadTracker.getFile(), response.getOutputStream(), 1024, true);
         }
 


### PR DESCRIPTION
When the layer download .zip file contains any .csv file, the file name of the .zip file is changed to CSVDownload.zip.
