### PR TITLE
Add new Google Maps API key

### DIFF
--- a/src/main/resources/config.properties
+++ b/src/main/resources/config.properties
@@ -3,7 +3,7 @@
 
 # Geoscience Portal CI at AWS
 portal-dev.vocabService.url=http://auscope-services-test.arrc.csiro.au/sissvoc/
-portal-dev.googlemap.key=ABQIAAAAbNveSfm3KAg3Jlr8E0ByDRRAL775K1PSt7WjH6RqN-M1Q-XicxRL8_0cjY65r7C2fshtMXufTmK8og
+portal-dev.googlemap.key=AIzaSyAVPT2oom0nGASf9OdADxkewqM98iC9z3g
 portal-dev.maxFeatures.value=200
 portal-dev.google.analytics.key=UA-79593123-1
 
@@ -102,7 +102,7 @@ PC-65069.piwik.site.id=2
 
 # Michael's workstation
 PC-65024.vocabService.url=http://auscope-services-test.arrc.csiro.au/sissvoc/
-PC-65024.googlemap.key=ABQIAAAAbNveSfm3KAg3Jlr8E0ByDRRAL775K1PSt7WjH6RqN-M1Q-XicxRL8_0cjY65r7C2fshtMXufTmK8og
+PC-65024.googlemap.key=AIzaSyAVPT2oom0nGASf9OdADxkewqM98iC9z3g
 PC-65024.maxFeatures.value=200
 
 # Brendan's workstation


### PR DESCRIPTION
Old one is for AuScope and they may have changed permissions for using it.
